### PR TITLE
Add retry logic when checking deployment state

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -525,7 +525,7 @@ module Kitchen
         begin
           resource_management_client.deployments.begin_create_or_update_async(resource_group, deployment_name, deployment)
         rescue Faraday::TimeoutError
-          info "Timed out while creating deployment '#{deployment_name}'. #{retries} retries left."
+          info "Timed out while sending deployment creation request for deployment '#{deployment_name}'. #{retries} retries left."
           raise if retries == 0
           retries -= 1
           retry


### PR DESCRIPTION
### What does this PR do?

Adds retry logic when using the Azure API. The number of retries is configurable in the `kitchen.yml` file, with the `azure_api_retries` option.

### Motivation

Prevent immediate failure when getting a timeout error.